### PR TITLE
ENH: improved error message `IndexError: too many indices for array`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,18 +218,34 @@ stages:
             OPENBLAS_SUFFIX: '64_'
     steps:
     - template: azure-steps-windows.yml
-  - job: Linux_PyPy3
+  # - job: Linux_PyPy3
+  #  pool:
+  #    vmIMage: 'ubuntu-18.04'
+  #  steps:
+  #  - script: source tools/pypy-test.sh
+  #    displayName: 'Run PyPy3 Build / Tests'
+  #  - task: PublishTestResults@2
+  #    condition: succeededOrFailed()
+  #    inputs:
+  #      testResultsFiles: '**/test-*.xml'
+  #      testRunTitle: 'Publish test results for PyPy3'
+  #      failTaskOnFailedTests: true
+  - job: Linux_18_04
     pool:
-      vmIMage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-18.04'
     steps:
-    - script: source tools/pypy-test.sh
-      displayName: 'Run PyPy3 Build / Tests'
+    - script: |
+            python3 -m pip install --user --upgrade pip setuptools
+            python3 -m pip install --user -r test_requirements.txt
+            CPPFLAGS='' F77=gfortran-5 F90=gfortran-5 \
+            python3 runtests.py --debug-info --mode=full -- -rsx --junitxml=junit/test-results.xml
+      displayName: 'Run Linux 18.04 Build / Tests'
     - task: PublishTestResults@2
       condition: succeededOrFailed()
       inputs:
         testResultsFiles: '**/test-*.xml'
-        testRunTitle: 'Publish test results for PyPy3'
         failTaskOnFailedTests: true
+        testRunTitle: 'Publish test results for gcc 4.8'
   - job: Linux_gcc48
     pool:
       vmImage: 'ubuntu-18.04'

--- a/doc/release/upcoming_changes/15802.expired.rst
+++ b/doc/release/upcoming_changes/15802.expired.rst
@@ -1,0 +1,9 @@
+`numpy.insert` and `numpy.delete` can no longer be passed an axis on 0d arrays
+------------------------------------------------------------------------------
+This concludes a deprecation from 1.9, where when an ``axis`` argument was
+passed to a call to `~numpy.insert` and `~numpy.delete` on a 0d array, the
+``axis`` and ``obj`` argument and indices would be completely ignored.
+In these cases, ``insert(arr, "nonsense", 42, axis=0)`` would actually overwrite the
+entire array, while ``delete(arr, "nonsense", axis=0)`` would be ``arr.copy()``
+
+Now passing ``axis`` on a 0d array raises `~numpy.AxisError`.

--- a/doc/release/upcoming_changes/15804.expired.rst
+++ b/doc/release/upcoming_changes/15804.expired.rst
@@ -1,0 +1,8 @@
+`numpy.delete` no longer ignores out-of-bounds indices
+------------------------------------------------------
+This concludes deprecations from 1.8 and 1.9, where ``np.delete`` would ignore
+both negative and out-of-bounds items in a sequence of indices. This was at
+odds with its behavior when passed a single index.
+
+Now out-of-bounds items throw ``IndexError``, and negative items index from the
+end.

--- a/doc/release/upcoming_changes/15805.expired.rst
+++ b/doc/release/upcoming_changes/15805.expired.rst
@@ -1,0 +1,6 @@
+`numpy.insert` and `numpy.delete` no longer accept non-integral indices
+-----------------------------------------------------------------------
+This concludes a deprecation from 1.9, where sequences of non-integers indices
+were allowed and cast to integers. Now passing sequences of non-integral
+indices raises ``IndexError``, just like it does when passing a single
+non-integral scalar.

--- a/doc/release/upcoming_changes/15815.expired.rst
+++ b/doc/release/upcoming_changes/15815.expired.rst
@@ -1,0 +1,6 @@
+`numpy.delete` no longer casts boolean indices to integers
+----------------------------------------------------------
+This concludes a deprecation from 1.8, where ``np.delete`` would cast boolean
+arrays and scalars passed as an index argument into integer indices. The
+behavior now is to treat boolean arrays as a mask, and to raise an error
+on boolean scalars.

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -729,7 +729,7 @@ prepare_index(PyArrayObject *self, PyObject *index,
     else if (used_ndim > PyArray_NDIM(self)) {
         PyErr_Format(PyExc_IndexError,
                      "too many indices for array: "
-                     "array has %d-dimension, but %d were indexed",
+                     "array is %d-dimensional, but %d were indexed",
                      PyArray_NDIM(self),
                      used_ndim);
         goto failed_building_indices;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -728,8 +728,8 @@ prepare_index(PyArrayObject *self, PyObject *index,
     }
     else if (used_ndim > PyArray_NDIM(self)) {
         PyErr_Format(PyExc_IndexError,
-                     "array has %"NPY_INTP_FMT
-                     "-dimension, but %d were indexed",
+                     "too many indices for array: "
+                     "array has %d-dimension, but %d were indexed",
                      PyArray_NDIM(self),
                      used_ndim);
         goto failed_building_indices;

--- a/numpy/core/src/multiarray/mapping.c
+++ b/numpy/core/src/multiarray/mapping.c
@@ -727,8 +727,11 @@ prepare_index(PyArrayObject *self, PyObject *index,
         }
     }
     else if (used_ndim > PyArray_NDIM(self)) {
-        PyErr_SetString(PyExc_IndexError,
-                        "too many indices for array");
+        PyErr_Format(PyExc_IndexError,
+                     "array has %"NPY_INTP_FMT
+                     "-dimension, but %d were indexed",
+                     PyArray_NDIM(self),
+                     used_ndim);
         goto failed_building_indices;
     }
     else if (index_ndim == 0) {

--- a/numpy/core/tests/test_einsum.py
+++ b/numpy/core/tests/test_einsum.py
@@ -605,6 +605,10 @@ class TestEinsum:
                      [[[1,  3], [3,  9], [5, 15], [7, 21]],
                      [[8, 16], [16, 32], [24, 48], [32, 64]]])
 
+        # Ensure explicitly setting out=None does not cause an error
+        # see issue gh-15776 and issue gh-15256
+        assert_equal(np.einsum('i,j', [1], [2], out=None), [[2]])
+
     def test_subscript_range(self):
         # Issue #7741, make sure that all letters of Latin alphabet (both uppercase & lowercase) can be used
         # when creating a subscript from arrays

--- a/numpy/core/tests/test_indexerrors.py
+++ b/numpy/core/tests/test_indexerrors.py
@@ -1,5 +1,8 @@
 import numpy as np
-from numpy.testing import assert_raises
+from numpy.testing import (
+        assert_raises, assert_raises_regex
+        )
+
 
 class TestIndexErrors:
     '''Tests to exercise indexerrors not covered by other tests.'''
@@ -109,6 +112,14 @@ class TestIndexErrors:
         a = np.zeros((3, 0))
         assert_raises(IndexError, lambda: a[(1, [0, 1])])
         assert_raises(IndexError, lambda: assign(a, (1, [0, 1]), 1))
+
+    def test_mapping_error_message(self):
+        a = np.zeros((3, 5))
+        index = (1, 2, 3, 4, 5)
+        assert_raises_regex(
+                IndexError,
+                "array has 2-dimension, but 5 were indexed",
+                lambda: a[index])
 
     def test_methods(self):
         "cases from methods.c"

--- a/numpy/core/tests/test_indexerrors.py
+++ b/numpy/core/tests/test_indexerrors.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import (
-        assert_raises, assert_raises_regex
+        assert_raises, assert_raises_regex,
         )
 
 
@@ -118,6 +118,7 @@ class TestIndexErrors:
         index = (1, 2, 3, 4, 5)
         assert_raises_regex(
                 IndexError,
+                "too many indices for array: "
                 "array has 2-dimension, but 5 were indexed",
                 lambda: a[index])
 

--- a/numpy/core/tests/test_indexerrors.py
+++ b/numpy/core/tests/test_indexerrors.py
@@ -119,7 +119,7 @@ class TestIndexErrors:
         assert_raises_regex(
                 IndexError,
                 "too many indices for array: "
-                "array has 2-dimension, but 5 were indexed",
+                "array is 2-dimensional, but 5 were indexed",
                 lambda: a[index])
 
     def test_methods(self):

--- a/numpy/core/tests/test_multiarray.py
+++ b/numpy/core/tests/test_multiarray.py
@@ -16,14 +16,7 @@ from contextlib import contextmanager
 
 from numpy.compat import pickle
 
-try:
-    import pathlib
-except ImportError:
-    try:
-        import pathlib2 as pathlib
-    except ImportError:
-        pathlib = None
-
+import pathlib
 import builtins
 from decimal import Decimal
 
@@ -4680,14 +4673,12 @@ class TestIO:
         y = np.fromfile(self.filename, dtype=self.dtype)
         assert_array_equal(y, self.x.flat)
 
-    @pytest.mark.skipif(pathlib is None, reason="pathlib not found")
     def test_roundtrip_pathlib(self):
         p = pathlib.Path(self.filename)
         self.x.tofile(p)
         y = np.fromfile(p, dtype=self.dtype)
         assert_array_equal(y, self.x.flat)
 
-    @pytest.mark.skipif(pathlib is None, reason="pathlib not found")
     def test_roundtrip_dump_pathlib(self):
         p = pathlib.Path(self.filename)
         self.x.dump(p)

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1408,6 +1408,11 @@ class TestRegression:
                      dtype='U')
         assert_raises(UnicodeEncodeError, np.array, a, 'S4')
 
+    def test_unicode_to_string_cast_error(self):
+        # gh-15790
+        a = np.array([u'\x80'] * 129, dtype='U3')
+        assert_raises(UnicodeEncodeError, np.array, a, 'S')
+
     def test_mixed_string_unicode_array_creation(self):
         a = np.array(['1234', u'123'])
         assert_(a.itemsize == 16)
@@ -2481,4 +2486,3 @@ class TestRegression:
         assert arr.size * arr.itemsize > 2 ** 31
         c_arr = np.ctypeslib.as_ctypes(arr)
         assert_equal(c_arr._length_, arr.size)
-

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1412,6 +1412,8 @@ class TestRegression:
         # gh-15790
         a = np.array([u'\x80'] * 129, dtype='U3')
         assert_raises(UnicodeEncodeError, np.array, a, 'S')
+        b = a.reshape(3, 43)[:-1, :-1]
+        assert_raises(UnicodeEncodeError, np.array, b, 'S')
 
     def test_mixed_string_unicode_array_creation(self):
         a = np.array(['1234', u'123'])

--- a/numpy/core/tests/test_regression.py
+++ b/numpy/core/tests/test_regression.py
@@ -1506,10 +1506,7 @@ class TestRegression:
                 test_type(t)
 
     def test_buffer_hashlib(self):
-        try:
-            from hashlib import md5
-        except ImportError:
-            from md5 import new as md5
+        from hashlib import md5
 
         x = np.array([1, 2, 3], dtype=np.dtype('<i4'))
         assert_equal(md5(x).hexdigest(), '2a1dd1e1e59d0a384c26951e316cd7e6')

--- a/numpy/f2py/tests/util.py
+++ b/numpy/f2py/tests/util.py
@@ -19,10 +19,7 @@ from numpy.compat import asbytes, asstr
 from numpy.testing import temppath
 from importlib import import_module
 
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import new as md5  # noqa: F401
+from hashlib import md5
 
 #
 # Maintaining a temporary module directory

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4273,15 +4273,6 @@ def delete(arr, obj, axis=None):
         # needed for np.matrix, which is still not 1d after being ravelled
         ndim = arr.ndim
         axis = ndim - 1
-    elif ndim == 0:
-        # 2013-09-24, 1.9
-        warnings.warn(
-            "in the future the special handling of scalars will be removed "
-            "from delete and raise an error", DeprecationWarning, stacklevel=3)
-        if wrap:
-            return wrap(arr)
-        else:
-            return arr.copy(order=arrorder)
     else:
         axis = normalize_axis_index(axis, ndim)
 
@@ -4515,17 +4506,6 @@ def insert(arr, obj, values, axis=None):
         # needed for np.matrix, which is still not 1d after being ravelled
         ndim = arr.ndim
         axis = ndim - 1
-    elif ndim == 0:
-        # 2013-09-24, 1.9
-        warnings.warn(
-            "in the future the special handling of scalars will be removed "
-            "from insert and raise an error", DeprecationWarning, stacklevel=3)
-        arr = arr.copy(order=arrorder)
-        arr[...] = values
-        if wrap:
-            return wrap(arr)
-        else:
-            return arr
     else:
         axis = normalize_axis_index(axis, ndim)
     slobj = [slice(None)]*ndim

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4379,23 +4379,6 @@ def delete(arr, obj, axis=None):
             obj = obj.astype(intp)
         keep = ones(N, dtype=bool)
 
-        # Test if there are out of bound indices, this is deprecated
-        inside_bounds = (obj < N) & (obj >= -N)
-        if not inside_bounds.all():
-            # 2013-09-24, NumPy 1.9
-            warnings.warn(
-                "in the future out of bounds indices will raise an error "
-                "instead of being ignored by `numpy.delete`.",
-                DeprecationWarning, stacklevel=3)
-            obj = obj[inside_bounds]
-        positive_indices = obj >= 0
-        if not positive_indices.all():
-            # 2013-04-11, NumPy 1.8
-            warnings.warn(
-                "in the future negative indices will not be ignored by "
-                "`numpy.delete`.", FutureWarning, stacklevel=3)
-            obj = obj[positive_indices]
-
         keep[obj, ] = False
         slobj[axis] = keep
         new = arr[tuple(slobj)]

--- a/numpy/lib/function_base.py
+++ b/numpy/lib/function_base.py
@@ -4369,14 +4369,6 @@ def delete(arr, obj, axis=None):
     else:
         if obj.size == 0 and not isinstance(_obj, np.ndarray):
             obj = obj.astype(intp)
-        if not np.can_cast(obj, intp, 'same_kind'):
-            # obj.size = 1 special case always failed and would just
-            # give superfluous warnings.
-            # 2013-09-24, 1.9
-            warnings.warn(
-                "using a non-integer array as obj in delete will result in an "
-                "error in the future", DeprecationWarning, stacklevel=3)
-            obj = obj.astype(intp)
         keep = ones(N, dtype=bool)
 
         # Test if there are out of bound indices, this is deprecated
@@ -4588,13 +4580,6 @@ def insert(arr, obj, values, axis=None):
         return new
     elif indices.size == 0 and not isinstance(obj, np.ndarray):
         # Can safely cast the empty list to intp
-        indices = indices.astype(intp)
-
-    if not np.can_cast(indices, intp, 'same_kind'):
-        # 2013-09-24, 1.9
-        warnings.warn(
-            "using a non-integer array as obj in insert will result in an "
-            "error in the future", DeprecationWarning, stacklevel=3)
         indices = indices.astype(intp)
 
     indices[indices < 0] += N

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -807,7 +807,6 @@ class TestDelete:
         # NOTE: The cast should be removed after warning phase for bools
         if not isinstance(indices, (slice, int, long, np.integer)):
             indices = np.asarray(indices, dtype=np.intp)
-            indices = indices[(indices >= 0) & (indices < 5)]
         assert_array_equal(setxor1d(a_del, self.a[indices, ]), self.a,
                            err_msg=msg)
         xor = setxor1d(nd_a_del[0,:, 0], self.nd_a[0, indices, 0])
@@ -825,10 +824,10 @@ class TestDelete:
     def test_fancy(self):
         # Deprecation/FutureWarning tests should be kept after change.
         self._check_inverse_of_slicing(np.array([[0, 1], [2, 1]]))
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error', category=DeprecationWarning)
-            assert_raises(DeprecationWarning, delete, self.a, [100])
-            assert_raises(DeprecationWarning, delete, self.a, [-100])
+        with pytest.raises(IndexError):
+            delete(self.a, [100])
+        with pytest.raises(IndexError):
+            delete(self.a, [-100])
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', category=FutureWarning)
             self._check_inverse_of_slicing([0, -1, 2, 2])

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -544,6 +544,12 @@ class TestInsert:
         b = np.insert(a, [0, 2], val)
         assert_array_equal(b[[0, 3]], np.array(val, dtype=b.dtype))
 
+    def test_index_floats(self):
+        with pytest.raises(IndexError):
+            np.insert([0, 1, 2], np.array([1.0, 2.0]), [10, 20])
+        with pytest.raises(IndexError):
+            np.insert([0, 1, 2], np.array([], dtype=float), [])
+
 
 class TestAmax:
 
@@ -867,6 +873,12 @@ class TestDelete:
         # same ordering as 'k' and NOT become C ordered
         assert_equal(m.flags.c_contiguous, k.flags.c_contiguous)
         assert_equal(m.flags.f_contiguous, k.flags.f_contiguous)
+
+    def test_index_floats(self):
+        with pytest.raises(IndexError):
+            np.delete([0, 1, 2], np.array([1.0, 2.0]))
+        with pytest.raises(IndexError):
+            np.delete([0, 1, 2], np.array([], dtype=float))
 
 
 class TestGradient:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -509,12 +509,11 @@ class TestInsert:
                      insert(a, 1, a[:, 2, :], axis=1))
 
     def test_0d(self):
-        # This is an error in the future
         a = np.array(1)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', DeprecationWarning)
-            assert_equal(insert(a, [], 2, axis=0), np.array(2))
-            assert_(w[0].category is DeprecationWarning)
+        with pytest.raises(np.AxisError):
+            insert(a, [], 2, axis=0)
+        with pytest.raises(TypeError):
+            insert(a, [], 2, axis="nonsense")
 
     def test_subclass(self):
         class SubClass(np.ndarray):
@@ -843,10 +842,10 @@ class TestDelete:
 
     def test_0d(self):
         a = np.array(1)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', DeprecationWarning)
-            assert_equal(delete(a, [], axis=0), a)
-            assert_(w[0].category is DeprecationWarning)
+        with pytest.raises(np.AxisError):
+            delete(a, [], axis=0)
+        with pytest.raises(TypeError):
+            delete(a, [], axis="nonsense")
 
     def test_subclass(self):
         class SubClass(np.ndarray):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -828,11 +828,15 @@ class TestDelete:
             delete(self.a, [100])
         with pytest.raises(IndexError):
             delete(self.a, [-100])
+
+        self._check_inverse_of_slicing([0, -1, 2, 2])
+
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', category=FutureWarning)
-            self._check_inverse_of_slicing([0, -1, 2, 2])
             obj = np.array([True, False, False], dtype=bool)
             self._check_inverse_of_slicing(obj)
+            # _check_inverse_of_slicing operates on two arrays, so warns twice
+            assert len(w) == 2
             assert_(w[0].category is FutureWarning)
             assert_(w[1].category is FutureWarning)
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6385,6 +6385,21 @@ class MaskedConstant(MaskedArray):
             # it's a subclass, or something is wrong, make it obvious
             return object.__repr__(self)
 
+    def __format__(self, format_spec):
+        # Replace ndarray.__format__ with the default, which supports no format characters.
+        # Supporting format characters is unwise here, because we do not know what type
+        # the user was expecting - better to not guess.
+        try:
+            return object.__format__(self, format_spec)
+        except TypeError:
+            # 2020-03-23, NumPy 1.19.0
+            warnings.warn(
+                "Format strings passed to MaskedConstant are ignored, but in future may "
+                "error or produce different behavior",
+                FutureWarning, stacklevel=2
+            )
+            return object.__format__(self, "")
+
     def __reduce__(self):
         """Override of MaskedArray's __reduce__.
         """

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -447,6 +447,21 @@ class TestMaskedArray:
         assert_equal(copied.mask, [0, 0, 0])
         assert_equal(a.mask, [0, 1, 0])
 
+    def test_format(self):
+        a = array([0, 1, 2], mask=[False, True, False])
+        assert_equal(format(a), "[0 -- 2]")
+        assert_equal(format(masked), "--")
+        assert_equal(format(masked, ""), "--")
+
+        # Postponed from PR #15410, perhaps address in the future.
+        # assert_equal(format(masked, " >5"), "   --")
+        # assert_equal(format(masked, " <5"), "--   ")
+
+        # Expect a FutureWarning for using format_spec with MaskedElement
+        with assert_warns(FutureWarning):
+            with_format_string = format(masked, " >5")
+        assert_equal(with_format_string, "--")
+
     def test_str_repr(self):
         a = array([0, 1, 2], mask=[False, True, False])
         assert_equal(str(a), '[0 -- 2]')


### PR DESCRIPTION
improved error message when the dimension of the index is larger than the dimension of the array

